### PR TITLE
Use root for assets path.

### DIFF
--- a/addon/services/worker.js
+++ b/addon/services/worker.js
@@ -49,7 +49,7 @@ export default Service.extend(Evented, {
 	 * @property webWorkersPath
 	 * @type String
 	 */
-	webWorkersPath: 'assets/web-workers/',
+	webWorkersPath: '/assets/web-workers/',
 
   /**
 	 * Initialize metadata array.


### PR DESCRIPTION
Hi there! Thanks for making this addon, it's saved me a bunch of time!

I'm running into a problem where a worker is trying to load via an incorrect URL. When I started the project, I was at the root url (`/`) so it was fine. But now that I moved my worker task to a new route (`/challenges`) I started getting this issue:
![screenshot 2017-04-23 at 9 19 02 pm](https://cloud.githubusercontent.com/assets/707107/25320202/af8596b8-286a-11e7-86f2-b67bd85bfa90.png)
I ended up throwing in an intializer to fix this in my app
```javascript
// /app/initializers/web-worker.js
import Ember from 'ember';
export function initialize(app) {
  const workers = app.__container__.lookup('service:worker');
  workers.set('webWorkersPath', '/assets/web-workers/');
}

export default {
  name: 'web-worker',
  worker: Ember.inject.service(),
  initialize
};
```
I'm guessing this will break if you're using a different baseUrl, but I wasn't sure if anyone else had run into this.