### PR TITLE
makes callback handler of off method as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ The worker will be alive until the event is detached.
 **Arguments**:  
 
   * `worker`: the name of the worker to create (used to create the file path `dist/assets/web-workers/${name}.js`).
-  * `callback`: callback to be executed each time worker sends a message (`postMessage`).
+  * `callback`: callback to be executed each time worker sends a message (`postMessage`). `callback` is optional for `off` method.
+  	- If `callback` is not	passed for `off` method, then all the instantiated worker with the passed name will be terminated
+  	- If `callback` is passed, then the corresponding worker associated with the callback will only be terminated.
 
 ```javascript
 // Some Ember context.

--- a/addon/services/worker.js
+++ b/addon/services/worker.js
@@ -206,13 +206,19 @@ export default Service.extend(Evented, {
    * @param Function callback
 	 */
 	off(name, callback) {
-		assert('Cannot unregister an event with no callback', typeof callback === 'function');
+		let metaArray;
 
-		const metaData = this.get('_cache').find((meta) => (name === meta.name && callback === meta.callback));
+		if (callback) {
+			assert('Callback should be a function', typeof callback === 'function');
+			const matchingWorker = this.get('_cache').find((meta) => (name === meta.name && callback === meta.callback));
 
-		if (metaData) {
-			this._cleanMeta(metaData);
+			metaArray = matchingWorker ? [matchingWorker] : [];
+		} else {
+			metaArray = this.get('_cache').filter((meta) => name === meta.name);
+		}
 
+		if (metaArray.length) {
+			metaArray.forEach((meta) => this._cleanMeta(meta));
 			return RSVP.resolve();
 		}
 

--- a/tests/unit/services/worker-test.js
+++ b/tests/unit/services/worker-test.js
@@ -149,17 +149,46 @@ test('it resolves promise when event stops', (assert) => {
 	});
 });
 
-test('it unsubscribes from a worker', (assert) => {
+test('it unsubscribes from a worker (passing a callback)', (assert) => {
 	assert.expect(2);
 
 	const callback = () => { };
-	const subscriptionPromise = service.on('subscription', callback);
+	const callback2 = () => { };
 
-	assert.equal(service.get('_cache.length'), 1);
+	const done = assert.async();
+	const subscriptionPromise = service.on('subscription', callback);
+	const subscriptionPromise2 = service.on('subscription', callback2);
+
+	assert.equal(service.get('_cache.length'), 2);
 
 	return subscriptionPromise.then(() => {
-		return service.off('subscription', callback).then(() => {
-			assert.equal(service.get('_cache.length'), 0);
+		subscriptionPromise2.then(() => {
+			service.off('subscription', callback).then(() => {
+				assert.equal(service.get('_cache.length'), 1, 'Only the worker associated with the callback has been terminated');
+				done();
+			});
+		});
+	});
+});
+
+test('it unsubscribes from a worker (without passing a callback)', (assert) => {
+	assert.expect(2);
+
+	const callback = () => { };
+	const callback2 = () => { };
+
+	const done = assert.async();
+	const subscriptionPromise = service.on('subscription', callback);
+	const subscriptionPromise2 = service.on('subscription', callback2);
+
+	assert.equal(service.get('_cache.length'), 2);
+
+	return subscriptionPromise.then(() => {
+		subscriptionPromise2.then(() => {
+			service.off('subscription').then(() => {
+				assert.equal(service.get('_cache.length'), 0, 'All the worker of the given name has been terminated');
+				done();
+			});
 		});
 	});
 });

--- a/tests/unit/services/worker-test.js
+++ b/tests/unit/services/worker-test.js
@@ -155,18 +155,14 @@ test('it unsubscribes from a worker (passing a callback)', (assert) => {
 	const callback = () => { };
 	const callback2 = () => { };
 
-	const done = assert.async();
 	const subscriptionPromise = service.on('subscription', callback);
 	const subscriptionPromise2 = service.on('subscription', callback2);
 
 	assert.equal(service.get('_cache.length'), 2);
 
-	return subscriptionPromise.then(() => {
-		subscriptionPromise2.then(() => {
-			service.off('subscription', callback).then(() => {
-				assert.equal(service.get('_cache.length'), 1, 'Only the worker associated with the callback has been terminated');
-				done();
-			});
+	return Promise.all([subscriptionPromise, subscriptionPromise2]).then(() => {
+		service.off('subscription', callback).then(() => {
+			assert.equal(service.get('_cache.length'), 1, 'Only the worker associated with the callback has been terminated');
 		});
 	});
 });
@@ -177,18 +173,14 @@ test('it unsubscribes from a worker (without passing a callback)', (assert) => {
 	const callback = () => { };
 	const callback2 = () => { };
 
-	const done = assert.async();
 	const subscriptionPromise = service.on('subscription', callback);
 	const subscriptionPromise2 = service.on('subscription', callback2);
 
 	assert.equal(service.get('_cache.length'), 2);
 
-	return subscriptionPromise.then(() => {
-		subscriptionPromise2.then(() => {
-			service.off('subscription').then(() => {
-				assert.equal(service.get('_cache.length'), 0, 'All the worker of the given name has been terminated');
-				done();
-			});
+	return Promise.all([subscriptionPromise, subscriptionPromise2]).then(() => {
+		service.off('subscription').then(() => {
+			assert.equal(service.get('_cache.length'), 0, 'All the worker of the given name has been terminated');
 		});
 	});
 });


### PR DESCRIPTION
makes callback handler of off method as optional. Terminates all worker with the passed name of no callback is passed.
Related Issue: #5 